### PR TITLE
Add hyphen-minus to special characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,8 @@ var SPECIAL_CHARACTERS = {
   '\u3002': '\ufe12',
   // 全角ハイフン
   '\u30fc': '\uff5c',
+  // 全角ハイフンマイナス
+  '\uff0d': '\uff5c',
   // "！" を中央寄せに
   '\uff01': '\ufe15'
 };


### PR DESCRIPTION
自分のところで `-` を半角入力した結果がハイフン/マイナスだったのと、元ネタでも対応してるっぽかったので追加しましたー。
## Refs
- [Unicodeにあるハイフン/マイナス/長音符/波線/チルダのコレクション | hydroculのメモ](https://hydrocul.github.io/wiki/blog/2014/1101-hyphen-minus-wave-tilde.html)
- [短冊メーカー Tanzaku Generator](http://tanzaku.ch3cooh.jp/)
